### PR TITLE
Update command to work with OWNER variable on newer Alpine Linux.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,7 +46,7 @@ fi
 
 # Deal with ownership
 if [ $OWNER -gt 0 ]; then
-    useradd webdrive -u $OWNER -N -G users
+    adduser webdrive -u $OWNER -D -G users
     chown webdrive $DEST
 fi
 


### PR DESCRIPTION
Alpine Linux does not have `useradd` command by default. Use `adduser` instead.