### PR TITLE
Remove useradd package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV WEBDRIVE_MOUNT=/mnt/webdrive
 # DAVFS2_ASK_AUTH=0 will set the davfs2 configuration option ask_auth to 0 for
 # that share. See the manual for the list of available options.
 
-RUN apk --no-cache add ca-certificates davfs2 tini useradd
+RUN apk --no-cache add ca-certificates davfs2 tini
 
 COPY *.sh /usr/local/bin/
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,7 @@ unset WEBDRIVE_PASSWORD
 if [ -n "$(env | grep "DAVFS2_")" ]; then
     echo "" >> /etc/davfs2/davfs2.conf
     echo "[$DEST]" >> /etc/davfs2/davfs2.conf
-    for VAR in $(env); do 
+    for VAR in $(env); do
         if [ -n "$(echo "$VAR" | grep -E '^DAVFS2_')" ]; then
             OPT_NAME=$(echo "$VAR" | sed -r "s/DAVFS2_([^=]*)=.*/\1/g" | tr '[:upper:]' '[:lower:]')
             VAR_FULL_NAME=$(echo "$VAR" | sed -r "s/([^=]*)=.*/\1/g")


### PR DESCRIPTION
The command `useradd` cannot be installed via an apk package and is not needed anymore since pull request #5. This way the build process doesn't fail anymore. 