### PR TITLE
Wait for davfs2 process to die

### DIFF
--- a/trap.sh
+++ b/trap.sh
@@ -5,7 +5,9 @@ exit_script() {
     dav2fs=$(ps -o pid= -o comm= | grep mount.davfs | sed -E 's/\s*(\d+)\s+.*/\1/g')
     if [ -n "$dav2fs" ]; then
         echo "Forwarding $SIGNAL to $dav2fs"
-        kill -$SIGNAL $dav2fs
+        while $(kill -$SIGNAL $dav2fs 2> /dev/null); do
+            sleep 1
+        done
     fi
     trap - $SIGNAL # clear the trap
     exit $?


### PR DESCRIPTION
Fixes #8 
After kill sends the corresponding signal to davfs2, the script does not wait for the process to terminate and exits - this behavior can lead to incomplete termination of davfs2 and leave the .pid file behind at `/var/run/mount.davfs/mnt-webdrive.pid` which prevents davfs2 to start again on restart.